### PR TITLE
feat: 지출(Expense) CRUD, 참여 인원수에 맞춰 금액을 분배(1/N) 구현

### DIFF
--- a/src/main/java/com/safely/domain/expense/ExpenseCategory.java
+++ b/src/main/java/com/safely/domain/expense/ExpenseCategory.java
@@ -1,0 +1,17 @@
+package com.safely.domain.expense;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ExpenseCategory {
+    FOOD("식비"),
+    TRANSPORT("교통"),
+    ACCOMMODATION("숙박"),
+    SHOPPING("쇼핑"),
+    ACTIVITY("액티비티"),
+    ETC("기타");
+
+    private final String description;
+}

--- a/src/main/java/com/safely/domain/expense/controller/ExpenseController.java
+++ b/src/main/java/com/safely/domain/expense/controller/ExpenseController.java
@@ -1,0 +1,49 @@
+package com.safely.domain.expense.controller;
+
+import com.safely.domain.expense.dto.ExpenseCreateRequest;
+import com.safely.domain.expense.dto.ExpenseResponse;
+import com.safely.domain.expense.service.ExpenseService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/groups/{groupId}/expenses")
+@RequiredArgsConstructor
+public class ExpenseController {
+    private final ExpenseService expenseService;
+
+    @PostMapping
+    public ResponseEntity<Long> createExpense(
+            @PathVariable Long groupId,
+            @Valid @RequestBody ExpenseCreateRequest request) {
+        Long expenseId = expenseService.createExpense(groupId, request);
+        return ResponseEntity.ok(expenseId);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<ExpenseResponse>> getExpenses(
+            @PathVariable Long groupId) {
+        return ResponseEntity.ok(expenseService.getExpenses(groupId));
+    }
+
+    @PutMapping("/{expenseId}")
+    public ResponseEntity<Void> updateExpense(
+            @PathVariable Long groupId,
+            @PathVariable Long expenseId,
+            @Valid @RequestBody ExpenseCreateRequest request) {
+        expenseService.updateExpense(groupId, expenseId, request);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{expenseId}")
+    public ResponseEntity<Void> deleteExpense(
+            @PathVariable Long groupId,
+            @PathVariable Long expenseId) {
+        expenseService.deleteExpense(groupId, expenseId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/safely/domain/expense/dto/ExpenseCreateRequest.java
+++ b/src/main/java/com/safely/domain/expense/dto/ExpenseCreateRequest.java
@@ -1,0 +1,15 @@
+package com.safely.domain.expense.dto;
+
+import com.safely.domain.expense.ExpenseCategory;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.util.List;
+
+public record ExpenseCreateRequest(
+        @NotNull(message = "결제일은 필수입니다.") LocalDate spentDate,
+        @NotNull(message = "장소는 필수입니다.") String location,
+        @NotNull(message = "항목은 필수입니다.") ExpenseCategory category,
+        @NotNull(message = "금액은 필수입니다.") Long amount,
+        @NotNull(message = "결제자는 필수입니다.") Long payerId, // 결제한 멤버의 ID
+        @NotNull(message = "참여 인원은 최소 1명 이상이어야 합니다.") List<Long> participantMemberIds // 함께한 멤버 ID 리스트
+) {}

--- a/src/main/java/com/safely/domain/expense/dto/ExpenseResponse.java
+++ b/src/main/java/com/safely/domain/expense/dto/ExpenseResponse.java
@@ -1,0 +1,27 @@
+package com.safely.domain.expense.dto;
+
+import com.safely.domain.expense.entity.Expense;
+import java.time.LocalDate;
+
+// 목록 조회용 DTO
+public record ExpenseResponse(
+        Long expenseId,
+        String location,
+        Long amount,
+        String payerName,
+        LocalDate spentDate,
+        String category,
+        int participantCount // "루크(결제) 외 N명" 표기를 위함
+) {
+    public static ExpenseResponse from(Expense expense) {
+        return new ExpenseResponse(
+                expense.getId(),
+                expense.getLocation(),
+                expense.getAmount(),
+                expense.getPayer().getName(), // 실제로는 GroupMember의 닉네임을 가져오면 더 좋음
+                expense.getSpentDate(),
+                expense.getCategory().getDescription(),
+                expense.getParticipants().size()
+        );
+    }
+}

--- a/src/main/java/com/safely/domain/expense/entity/Expense.java
+++ b/src/main/java/com/safely/domain/expense/entity/Expense.java
@@ -1,0 +1,90 @@
+package com.safely.domain.expense.entity;
+
+import com.safely.domain.common.entity.BaseEntity;
+import com.safely.domain.expense.ExpenseCategory;
+import com.safely.domain.group.entity.Group;
+import com.safely.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Table(name = "expenses")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Expense extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "expense_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_id", nullable = false)
+    private Group group;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "payer_id", nullable = false)
+    private Member payer; // 결제자 (실제 돈을 낸 사람)
+
+    @Column(nullable = false)
+    private Long amount; // 총 지출 금액
+
+    @Column(nullable = false)
+    private String location; // 장소
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ExpenseCategory category; // 항목 (식비, 교통 등)
+
+    @Column(nullable = false)
+    private LocalDate spentDate; // 결제일
+
+    // CascadeType.ALL + orphanRemoval = true : 지출 삭제 시 분담 내역도 함께 삭제
+    @OneToMany(mappedBy = "expense", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ExpenseParticipant> participants = new ArrayList<>();
+
+    @Builder
+    public Expense(Group group, Member payer, Long amount, String location, ExpenseCategory category, LocalDate spentDate) {
+        this.group = group;
+        this.payer = payer;
+        this.amount = amount;
+        this.location = location;
+        this.category = category;
+        this.spentDate = spentDate;
+    }
+
+    // 수정 메서드
+    public void update(Member payer, Long amount, String location, ExpenseCategory category, LocalDate spentDate) {
+        this.payer = payer;
+        this.amount = amount;
+        this.location = location;
+        this.category = category;
+        this.spentDate = spentDate;
+    }
+
+    // 연관관계 편의 메서드
+    public void addParticipant(ExpenseParticipant participant) {
+        this.participants.add(participant);
+    }
+
+    // 참여자 목록 초기화 (수정 시 사용)
+    // @OneToMany(mappedBy = "expense", cascade = CascadeType.ALL, orphanRemoval = true)
+    // 원래는 ArrayList<>()의 clear() 메서드 사용하면 메모리에서만 삭제되어야 하지만, 엔티티 클래스 안에서 orphanRemoval = true
+    // 옵션 주면 DB까지 같이 삭제됨.
+    //
+    // JPA에서의 특별한 의미 (중요!) (출처: 제미나이 3.0 pro)
+    // 그냥 자바 ArrayList에서는 clear()를 하면 "메모리에서만" 데이터가 사라지지만, JPA 엔티티 안에서 사용할 때는 DB 데이터 삭제로
+    // 이어지는 강력한 기능을 합니다.
+    // 설정: @OneToMany(..., orphanRemoval = true)
+    // 동작: this.participants.clear()가 호출되면, JPA는 "어? 리스트에서 객체들이 없어졌네? 고아(Orphan)가 되었으니 DB에서도 지워야지!"
+    // 라고 판단하고 DELETE 쿼리를 날려줍니다.
+    public void clearParticipants() {
+        this.participants.clear();
+    }
+}

--- a/src/main/java/com/safely/domain/expense/entity/ExpenseParticipant.java
+++ b/src/main/java/com/safely/domain/expense/entity/ExpenseParticipant.java
@@ -1,0 +1,37 @@
+package com.safely.domain.expense.entity;
+
+import com.safely.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "expense_participants")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ExpenseParticipant {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "expense_participant_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "expense_id", nullable = false)
+    private Expense expense;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member; // 비용을 분담해야 할 사람
+
+    @Column(nullable = false)
+    private Long amount; // 이 사람이 내야 할 금액 (1/N 된 금액)
+
+    @Builder
+    public ExpenseParticipant(Expense expense, Member member, Long amount) {
+        this.expense = expense;
+        this.member = member;
+        this.amount = amount;
+    }
+}

--- a/src/main/java/com/safely/domain/expense/repository/ExpenseRepository.java
+++ b/src/main/java/com/safely/domain/expense/repository/ExpenseRepository.java
@@ -1,0 +1,15 @@
+package com.safely.domain.expense.repository;
+
+import com.safely.domain.expense.entity.Expense;
+import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface ExpenseRepository extends JpaRepository<Expense, Long> {
+    // 그룹별 지출 내역 조회 (최신순)
+    // N+1 문제 방지를 위해 payer 정보를 Fetch Join
+    @Query("SELECT e FROM Expense e JOIN FETCH e.payer WHERE e.group.id = :groupId ORDER BY e.spentDate DESC, e.createdAt DESC")
+    List<Expense> findAllByGroupId(@Param("groupId") Long groupId);
+}

--- a/src/main/java/com/safely/domain/expense/service/ExpenseService.java
+++ b/src/main/java/com/safely/domain/expense/service/ExpenseService.java
@@ -1,0 +1,127 @@
+package com.safely.domain.expense.service;
+
+import com.safely.domain.expense.dto.ExpenseCreateRequest;
+import com.safely.domain.expense.dto.ExpenseResponse;
+import com.safely.domain.expense.entity.Expense;
+import com.safely.domain.expense.entity.ExpenseParticipant;
+import com.safely.domain.expense.repository.ExpenseRepository;
+import com.safely.domain.group.entity.Group;
+import com.safely.domain.group.repository.GroupRepository;
+import com.safely.domain.member.entity.Member;
+import com.safely.domain.member.repository.MemberRepository;
+import com.safely.global.exception.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ExpenseService {
+    private final ExpenseRepository expenseRepository;
+    private final GroupRepository groupRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public Long createExpense(Long groupId, ExpenseCreateRequest request) {
+        Group group = groupRepository.findById(groupId)
+                .orElseThrow(NotFoundException::new);
+
+        Member payer = memberRepository.findById(request.payerId())
+                .orElseThrow(NotFoundException::new);
+
+        // 지출 엔티티 생성
+        Expense expense = Expense.builder()
+                .group(group)
+                .payer(payer)
+                .amount(request.amount())
+                .location(request.location())
+                .category(request.category())
+                .spentDate(request.spentDate())
+                .build();
+
+        // 1/N 분배 로직 실행 및 참여자 저장
+        distributeAmountAndSaveParticipants(expense, request.amount(), request.participantMemberIds());
+
+        expenseRepository.save(expense);
+        return expense.getId();
+    }
+
+    // 2. 지출 내역 목록 조회
+    public List<ExpenseResponse> getExpenses(Long groupId) {
+        return expenseRepository. findAllByGroupId(groupId).stream()
+                .map(ExpenseResponse::from)
+                .toList();
+    }
+
+    // 3. 지출 내역 수정
+    @Transactional
+    public void updateExpense(Long groupId, Long expenseId, ExpenseCreateRequest request) {
+        Expense expense = expenseRepository.findById(expenseId)
+                .orElseThrow(NotFoundException::new);
+
+        validateGroupAccess(expense, groupId);
+
+        Member newPayer = memberRepository.findById(request.payerId())
+                .orElseThrow(NotFoundException::new);
+
+        // 기본 정보 업데이트
+        expense.update(newPayer, request.amount(), request.location(), request.category(), request.spentDate());
+
+        // 기존 참여자 목록 삭제 후 재생성 (가장 깔끔한 갱신 방법)
+        expense.clearParticipants();
+        distributeAmountAndSaveParticipants(expense, request.amount(), request.participantMemberIds());
+    }
+
+    // 4. 지출 내역 삭제
+    @Transactional
+    public void deleteExpense(Long groupId, Long expenseId) {
+        Expense expense = expenseRepository.findById(expenseId)
+                .orElseThrow(NotFoundException::new);
+
+        validateGroupAccess(expense, groupId);
+
+        expenseRepository.delete(expense);
+    }
+
+    // 금액 분배 및 참여자 생성 로직 (1/N + 나머지 처리)
+    private void distributeAmountAndSaveParticipants(Expense expense, Long totalAmount, List<Long> participantIds) {
+        if (participantIds == null || participantIds.isEmpty()) {
+            throw new IllegalArgumentException("참여 인원은 최소 1명 이상이어야 합니다.");
+        }
+
+        List<Member> members = memberRepository.findAllById(participantIds);
+        if (members.size() != participantIds.size()) {
+            throw new IllegalArgumentException("존재하지 않는 멤버가 포함되어 있습니다.");
+        }
+
+        int count = members.size();
+        long splitAmount = totalAmount / count; // 몫
+        long remainder = totalAmount % count;   // 나머지
+
+        for (int i = 0; i < count; i++) {
+            long individualAmount = splitAmount;
+
+            // 나머지는 첫 번째 사람에게 부과 (예: 10,000원 / 3명 -> 3,334 / 3,333 / 3,333)
+            if (i == 0) {
+                individualAmount += remainder;
+            }
+
+            ExpenseParticipant participant = ExpenseParticipant.builder()
+                    .expense(expense)
+                    .member(members.get(i))
+                    .amount(individualAmount)
+                    .build();
+
+            expense.addParticipant(participant);
+        }
+    }
+
+    private void validateGroupAccess(Expense expense, Long groupId) {
+        if (!expense.getGroup().getId().equals(groupId)) {
+            throw new IllegalArgumentException("해당 그룹의 지출 내역이 아닙니다.");
+        }
+    }
+}


### PR DESCRIPTION
## 📌 이슈 번호

- resolves #11 

## 🔎 변경 내용

- Expense, ExpenseParticipant 엔티티 작성, ExpenseCategory Enum 형식 작성
- 서비스, 컨트롤러, 리포지토리 작성
- N+1 문제 해결. findAllByGroupId 목록 조회 시 FETCH JOIN을 사용함.

## 📬 참고 사항

- GlobalExceptionHandler 예외 처리는 추후 구현할 예정임.
