### PR TITLE
feat: 정산(Settlement) 알고리즘 및 API 구현

### DIFF
--- a/src/main/java/com/safely/domain/settlement/controller/SettlementController.java
+++ b/src/main/java/com/safely/domain/settlement/controller/SettlementController.java
@@ -1,0 +1,37 @@
+package com.safely.domain.settlement.controller;
+
+import com.safely.domain.settlement.dto.SettlementResponse;
+import com.safely.domain.settlement.service.SettlementService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/groups/{groupId}/settlements")
+@RequiredArgsConstructor
+public class SettlementController {
+
+    private final SettlementService settlementService;
+
+    // 1. 정산 프리뷰 (단순 조회)
+    @GetMapping("/preview")
+    public ResponseEntity<List<SettlementResponse>> previewSettlement(@PathVariable Long groupId) {
+        return ResponseEntity.ok(settlementService.getSettlementPreview(groupId));
+    }
+
+    // 2. 정산 완료 (확정 저장)
+    @PostMapping("/complete")
+    public ResponseEntity<Void> completeSettlement(@PathVariable Long groupId) {
+        settlementService.completeSettlement(groupId);
+        return ResponseEntity.ok().build();
+    }
+
+    // 3. 정산 취소 (초기화)
+    @PostMapping("/cancel")
+    public ResponseEntity<Void> cancelSettlement(@PathVariable Long groupId) {
+        settlementService.cancelSettlement(groupId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/safely/domain/settlement/dto/SettlementResponse.java
+++ b/src/main/java/com/safely/domain/settlement/dto/SettlementResponse.java
@@ -1,0 +1,36 @@
+package com.safely.domain.settlement.dto;
+
+import com.safely.domain.member.entity.Member;
+import com.safely.domain.settlement.entity.Settlement;
+
+public record SettlementResponse(
+        Long memberId,
+        String memberName,
+        String profileImage,
+        Long netAmount,      // 최종 정산 금액 (+/-)
+        Long sendAmount,     // 보낼 돈 (양수 변환)
+        Long receiveAmount   // 받을 돈
+) {
+    public static SettlementResponse of(Member member, Long netAmount) {
+        long send = 0;
+        long receive = 0;
+
+        // 양수(+)면 받을 돈, 음수(-)면 보낼 돈
+        if (netAmount > 0) receive = netAmount;
+        else if (netAmount < 0) send = Math.abs(netAmount);
+
+        return new SettlementResponse(
+                member.getId(),
+                member.getName(),
+                member.getProfileImage(),
+                netAmount,
+                send,
+                receive
+        );
+    }
+
+    // Entity -> DTO 변환
+    public static SettlementResponse from(Settlement settlement) {
+        return SettlementResponse.of(settlement.getMember(), settlement.getNetAmount());
+    }
+}

--- a/src/main/java/com/safely/domain/settlement/entity/Settlement.java
+++ b/src/main/java/com/safely/domain/settlement/entity/Settlement.java
@@ -1,0 +1,61 @@
+package com.safely.domain.settlement.entity;
+
+import com.safely.domain.common.entity.BaseEntity;
+import com.safely.domain.group.entity.Group;
+import com.safely.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Table(name = "settlements")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Settlement extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "settlement_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_id", nullable = false)
+    private Group group;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    // 최종 정산 금액 (양수: 받을 돈 / 음수: 보낼 돈)
+    @Column(name = "net_amount", nullable = false)
+    private Long netAmount;
+
+    @Column(name = "is_settled", nullable = false)
+    private boolean isSettled;
+
+    // 정산 확정 일시 (시간 포함)
+    @Column(name = "settled_at")
+    private LocalDateTime settledAt;
+
+    @Builder
+    public Settlement(Group group, Member member, Long netAmount, boolean isSettled) {
+        this.group = group;
+        this.member = member;
+        this.netAmount = netAmount;
+        this.isSettled = isSettled;
+        if (isSettled) {
+            this.settledAt = LocalDateTime.now();
+        }
+    }
+
+    // 정산 결과 업데이트 (재정산 또는 취소 시)
+    public void update(Long netAmount, boolean isSettled) {
+        this.netAmount = netAmount;
+        this.isSettled = isSettled;
+        // 정산 완료(true)면 현재 시간, 취소(false)면 null
+        this.settledAt = isSettled ? LocalDateTime.now() : null;
+    }
+}

--- a/src/main/java/com/safely/domain/settlement/repository/SettlementRepository.java
+++ b/src/main/java/com/safely/domain/settlement/repository/SettlementRepository.java
@@ -1,0 +1,19 @@
+package com.safely.domain.settlement.repository;
+
+import com.safely.domain.settlement.entity.Settlement;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface SettlementRepository extends JpaRepository<Settlement, Long> {
+    // 그룹 내 특정 멤버의 정산 기록 조회 (Upsert용(Upsert = Update + Insert))
+    Optional<Settlement> findByGroupIdAndMemberId(Long groupId, Long memberId);
+
+    // 그룹의 정산 내역 전체 조회 (화면 표시용)
+    // N+1 문제 방지를 위해 Member fetch join
+    @Query("SELECT s FROM Settlement s JOIN FETCH s.member WHERE s.group.id = :groupId")
+    List<Settlement> findAllByGroupId(@Param("groupId") Long groupId);
+}

--- a/src/main/java/com/safely/domain/settlement/service/SettlementService.java
+++ b/src/main/java/com/safely/domain/settlement/service/SettlementService.java
@@ -1,0 +1,128 @@
+package com.safely.domain.settlement.service;
+
+import com.safely.domain.expense.entity.Expense;
+import com.safely.domain.expense.repository.ExpenseRepository;
+import com.safely.domain.group.entity.Group;
+import com.safely.domain.group.entity.GroupMember;
+import com.safely.domain.group.repository.GroupMemberRepository;
+import com.safely.domain.group.repository.GroupRepository;
+import com.safely.domain.member.entity.Member;
+import com.safely.domain.settlement.dto.SettlementResponse;
+import com.safely.domain.settlement.entity.Settlement;
+import com.safely.domain.settlement.repository.SettlementRepository;
+import com.safely.global.exception.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SettlementService {
+
+    private final ExpenseRepository expenseRepository;
+    private final GroupMemberRepository groupMemberRepository;
+    private final SettlementRepository settlementRepository;
+    private final GroupRepository groupRepository;
+
+    // 1. 정산 프리뷰 (DB 저장 X, 계산 결과만 반환)
+    public List<SettlementResponse> getSettlementPreview(Long groupId) {
+        // 그룹 멤버와 지출 내역 조회
+        List<GroupMember> groupMembers = findGroupMembers(groupId);
+
+        // 여기서 null 값 처리를 안 하는 이유는 List나 set은 값이 없을 경우 비어있는 리스트를 반환하기 때문임.
+        List<Expense> expenses = expenseRepository.findAllByGroupId(groupId);
+
+        // 계산 로직 수행
+        Map<Member, Long> resultMap = calculateSettlement(groupMembers, expenses);
+
+        // 결과 DTO 변환 및 반환
+        return resultMap.entrySet().stream()
+                .map(entry -> SettlementResponse.of(entry.getKey(), entry.getValue()))
+                .toList();
+    }
+
+    // 2. 정산 완료 (계산 후 DB 저장)
+    @Transactional
+    public void completeSettlement(Long groupId) {
+        Group group = groupRepository.findById(groupId)
+                .orElseThrow(NotFoundException::new);
+
+        List<GroupMember> groupMembers = findGroupMembers(groupId);
+        List<Expense> expenses = expenseRepository.findAllByGroupId(groupId);
+
+        Map<Member, Long> resultMap = calculateSettlement(groupMembers, expenses);
+
+        // DB Upsert (기존 내역 있으면 업데이트, 없으면 생성)
+        for (Map.Entry<Member, Long> entry : resultMap.entrySet()) {
+            Member member = entry.getKey();
+            Long netAmount = entry.getValue();
+
+            // 여기서 orElse 대신 orElseGet(함수)를 사용하는 이유 : orElse는 new Settlement()를 실행해서 낭비발생할 여지가 있음.
+            // 반면에 orElseGet()은 DB에 데이터가 있으면, 괄호안의 코드를 아예 실행하지 않아서 효율적임.
+            Settlement settlement = settlementRepository.findByGroupIdAndMemberId(groupId, member.getId())
+                    .orElseGet(() -> Settlement.builder()
+                            .group(group)
+                            .member(member)
+                            .netAmount(0L)
+                            .isSettled(false)
+                            .build());
+
+            // 정산 확정 (netAmount 저장, isSettled=true, settledAt=now)
+            settlement.update(netAmount, true);
+            settlementRepository.save(settlement);
+        }
+    }
+
+    // 3. 정산 취소 (0원으로 초기화)
+    // 여기서 settlementRepository.save(settlement);를 수행하지 않는 이유는 영속성 컨텍스트의 변경감지(Dirty Checking) 기능 때문임.
+    // @Transactional 어노테이션 때문에, 영속성 컨텍스트가 활성화 되는데, 메서드 종료 시점에 JPA는 "최초 시점"과 "현재 객체 상태"를 비교.
+    // 변경된 부분(Dirty)이 감지되면, JPA가 알아서 UPdATE SQL을 생성하여 DB에 날림.
+    // 따라서, 조회한 엔티티의 값을 수정하는 로직에서는 save()를 명시적으로 호출하지 않는 것이 JPA의 표준 관례(Idiom)임.
+    // 만약, @Transactional 어노테이션이 없으면 save()가 필요함.
+    @Transactional
+    public void cancelSettlement(Long groupId) {
+        List<Settlement> settlements = settlementRepository.findAllByGroupId(groupId);
+        for (Settlement settlement : settlements) {
+            // 초기화 (netAmount=0, isSettled=false, settledAt=null)
+            settlement.update(0L, false);
+        }
+    }
+
+    // 헬퍼 메서드
+    private List<GroupMember> findGroupMembers(Long groupId) {
+        return groupMemberRepository.findAll().stream()
+                .filter(gm -> gm.getGroup().getId().equals(groupId))
+                .toList();
+    }
+
+    // 정산 알고리즘 (핵심)
+    private Map<Member, Long> calculateSettlement(List<GroupMember> groupMembers, List<Expense> expenses) {
+        Map<Member, Long> balanceMap = new HashMap<>();
+
+        // 모든 멤버 0원으로 초기화
+        for (GroupMember gm : groupMembers) {
+            balanceMap.put(gm.getMember(), 0L);
+        }
+
+        for (Expense expense : expenses) {
+            Member payer = expense.getPayer();
+            Long totalAmount = expense.getAmount();
+
+            // A. 결제자: (+) 받을 권리 증가
+            balanceMap.put(payer, balanceMap.getOrDefault(payer, 0L) + totalAmount);
+
+            // B. 참여자: (-) 내야 할 의무 증가
+            expense.getParticipants().forEach(participant -> {
+                Member m = participant.getMember();
+                Long splitAmount = participant.getAmount();
+                balanceMap.put(m, balanceMap.getOrDefault(m, 0L) - splitAmount);
+            });
+        }
+        return balanceMap;
+    }
+}


### PR DESCRIPTION
## 📌 이슈 번호

- resolves #13

## 🔎 변경 내용

**1. 정산 도메인(Settlement) 설계 및 구현**
- `Settlement` 엔티티를 생성하여 정산 결과를 저장
- `netAmount`(순 정산액)와 `settledAt`(정산 확정 일시) 필드 적용

**2. 정산 알고리즘 (SettlementService)**
- `Preview`: DB에 저장하지 않고, 현재 지출 내역을 바탕으로 실시간 계산 결과 반환
- `Complete`: 계산된 결과를 DB에 저장(Upsert)하며, `isSettled=true` 상태로 변경
- `Cancel`: 정산 내역을 삭제하지 않고 금액을 0원으로 초기화

**3. API 엔드포인트**
- `GET /api/groups/{groupId}/settlements/preview`: 정산 미리보기
- `POST /api/groups/{groupId}/settlements/complete`: 정산 확정
- `POST /api/groups/{groupId}/settlements/cancel`: 정산 취소

## 📬 참고 사항

- 결제자(Payer)는 전체 금액만큼 `+`, 참여자(Participant)는 본인 부담금만큼 `-` 하여 합산
