### PR TITLE
docs: Swagger(SpringDoc) 라이브러리 추가 및 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ dependencies {
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
     implementation 'io.jsonwebtoken:jjwt-api:0.13.0'
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.4.1'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.14'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/safely/domain/expense/entity/Expense.java
+++ b/src/main/java/com/safely/domain/expense/entity/Expense.java
@@ -19,8 +19,8 @@ import java.util.List;
 @Table(name = "expenses")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Expense extends BaseEntity {
-
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "expense_id")
     private Long id;
 

--- a/src/main/java/com/safely/domain/expense/entity/ExpenseParticipant.java
+++ b/src/main/java/com/safely/domain/expense/entity/ExpenseParticipant.java
@@ -12,8 +12,8 @@ import lombok.NoArgsConstructor;
 @Table(name = "expense_participants")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ExpenseParticipant {
-
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "expense_participant_id")
     private Long id;
 

--- a/src/main/java/com/safely/domain/member/controller/MemberController.java
+++ b/src/main/java/com/safely/domain/member/controller/MemberController.java
@@ -14,7 +14,6 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 @RequestMapping("/api/members")
 public class MemberController {
-
     private final MemberService memberService;
 
     // 1. 내 정보 조회

--- a/src/main/java/com/safely/domain/member/service/MemberService.java
+++ b/src/main/java/com/safely/domain/member/service/MemberService.java
@@ -15,7 +15,6 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class MemberService {
-
     private final MemberRepository memberRepository;
     private final S3Service s3Service;
     private final PasswordEncoder passwordEncoder;

--- a/src/main/java/com/safely/domain/settlement/controller/SettlementController.java
+++ b/src/main/java/com/safely/domain/settlement/controller/SettlementController.java
@@ -12,7 +12,6 @@ import java.util.List;
 @RequestMapping("/api/groups/{groupId}/settlements")
 @RequiredArgsConstructor
 public class SettlementController {
-
     private final SettlementService settlementService;
 
     // 1. 정산 프리뷰 (단순 조회)

--- a/src/main/java/com/safely/domain/settlement/service/SettlementService.java
+++ b/src/main/java/com/safely/domain/settlement/service/SettlementService.java
@@ -23,7 +23,6 @@ import java.util.Map;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class SettlementService {
-
     private final ExpenseRepository expenseRepository;
     private final GroupMemberRepository groupMemberRepository;
     private final SettlementRepository settlementRepository;

--- a/src/main/java/com/safely/global/config/SwaggerConfig.java
+++ b/src/main/java/com/safely/global/config/SwaggerConfig.java
@@ -1,0 +1,28 @@
+package com.safely.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components()
+                        .addSecuritySchemes("bearer-key",
+                                new SecurityScheme()
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")))
+                .addSecurityItem(new SecurityRequirement().addList("bearer-key"))
+                .info(new Info()
+                        .title("Safely API Document")
+                        .description("Safely 프로젝트의 API 명세서입니다.")
+                        .version("v1.0.0"));
+    }
+}

--- a/src/main/java/com/safely/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/safely/global/security/config/SecurityConfig.java
@@ -22,7 +22,10 @@ public class SecurityConfig {
     private final String[] authUrls = {
             "/",
             "/api/auth/**",
-            "/h2-console/**"
+            "/h2-console/**",
+            "/v3/api-docs/**",
+            "/swagger-ui/**",
+            "/swagger-ui.html"
     };
 
     @Bean

--- a/src/main/java/com/safely/global/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/safely/global/security/filter/JwtAuthenticationFilter.java
@@ -19,7 +19,6 @@ import java.io.IOException;
 @Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
-
     private final JwtProvider jwtProvider;
     private final RedisTemplate<String, String> redisTemplate;
     private final AntPathMatcher pathMatcher = new AntPathMatcher();
@@ -34,7 +33,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 "/api/auth/**",
                 "/h2-console/**",
                 "/swagger-ui/**",
-                "/v3/**"
+                "/swagger-ui.html",
+                "/v3/api-docs/**"
         };
 
         for (String pattern : whiteList) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -48,6 +48,9 @@ spring:
         max-file-size: 10MB
         max-request-size: 10MB
 
+#  main:
+#    allow-bean-definition-overriding: true  # 의존성 충돌이 나면 빈 덮어 씌우기 (swagger 최신버전으로 했다가 오류떠서 시도해 봄.)
+
 jwt:
   secret-key: "your-very-long-jwt-secret-key-should-be-very-long" # 개발 단계 기본 비밀번호 이므로 GitHub에 그냥 올림.
   access-token-expire-ms: 900000      # 15분


### PR DESCRIPTION
## 📌 이슈 번호

- resolves #15

## 🔎 변경 내용

- **build.gradle**: `springdoc-openapi-starter-webmvc-ui` 의존성 추가
- **SwaggerConfig**: API 문서에서 JWT 토큰을 입력할 수 있도록 `SecurityScheme` 설정 추가
- **SecurityConfig & JwtFilter**: 로그인 없이 Swagger 페이지(`http://localhost:8080/swagger-ui/index.html`)에 접근할 수 있도록 보안 설정 해제

## 📬 참고 사항

- `/swagger-ui/index.html` 로 접속하여 테스트 가능합니다.
- org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.0 (2025-12-12 현재 가장 최신버전) 했다가 의존성 충돌나서 2.8.14버전(2.8.x대에서 현재 가장 최신 버전)으로 빌드했습니다.
