### PR TITLE
ci_cd: AWS EB 및 GitHub Actions CI/CD 파이프라인 구축

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,56 @@
+name: Safely CI/CD
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      # --- [CI 구간] ---
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      # application-prod.yml 같은 파일이 git에 없다면 여기서 생성해주는 단계가 필요할 수 있음
+      # 하지만 위에서 변수 처리(${...}) 했으므로 파일만 있으면 됨.
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew clean build -x test
+        # 테스트 실패 시 배포 중단을 원하면 -x test 제거.
+        # 현재 Redis가 없어서 테스트 실패 가능성이 있으므로 일단 스킵(-x test) 권장.
+
+      # --- [CD 구간] ---
+      - name: Generate deployment package
+        run: |
+          zip -r deploy.zip . -x "*.git*" "build/libs/*-plain.jar"
+          # 필요한 파일들만 압축 (JAR 파일이 포함되도록 build 폴더 포함 확인 필요, 
+          # 보통 Docker 배포는 소스코드 + Dockerfile만 넘기면 EB가 알아서 빌드하거나,
+          # 위처럼 JAR를 미리 만들었다면 Dockerfile COPY 경로에 주의해야 함.)
+
+        # [중요 수정] AWS EB Docker 플랫폼은 기본적으로
+        # 1. Dockerfile이 있으면 -> Docker build 수행
+        # 2. docker-compose.yml이 있으면 -> Compose 수행
+        # 여기서는 "소스 코드 + Dockerfile"을 넘겨서 EB가 "docker build"를 하게 만드는 방식입니다.
+        # 따라서 ./gradlew build로 생긴 jar 파일도 zip에 포함되어야 Dockerfile의 COPY 명령어가 작동합니다.
+
+      - name: Deploy to Elastic Beanstalk
+        uses: einaregilsson/beanstalk-deploy@v21
+        with:
+          aws_access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          application_name: safely-app          # AWS EB 앱 이름
+          environment_name: Safely-app-env       # AWS EB 환경 이름
+          version_label: "ver-${{ github.sha }}"
+          region: ${{ secrets.AWS_REGION }}
+          deployment_package: deploy.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# 1. Base Image: Java 21 (Temurin 배포판 권장)
+FROM eclipse-temurin:21-jdk-alpine
+
+# 2. 작업 디렉토리 설정
+WORKDIR /app
+
+# 3. 빌드된 JAR 파일을 Docker 이미지 안으로 복사
+# Gradle 빌드 시 build/libs/ 안에 jar가 생김
+COPY build/libs/*.jar app.jar
+
+# 4. 운영 환경 프로필(prod) 적용
+ENV SPRING_PROFILES_ACTIVE=prod
+
+# 5. 실행 명령어
+ENTRYPOINT ["java", "-jar", "app.jar"]
+
+# 6. 포트 노출 (AWS EB가 이 포트로 트래픽을 보냄)
+EXPOSE 8080

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.13.0'
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.4.1'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.14'
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-parameter-store'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '3.8'
+
+services:
+  # 1. Spring Boot 애플리케이션
+  app:
+    build: .                    # 현재 폴더의 Dockerfile을 사용하여 빌드
+    ports:
+      - "80:8080"               # 외부 80 포트로 들어오면 -> 내부 8080(Spring)으로 연결
+    environment:
+      # [프로필 설정]
+      SPRING_PROFILES_ACTIVE: prod
+
+      # [Redis 설정] 'redis' 서비스 컨테이너와 연결
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+#      REDIS_PASSWORD: ${REDIS_PASSWORD} # AWS 파라미터 스토어에 spring.data.redis.password 등록되어 있어서 필요 없음.
+
+      # [AWS EB 환경변수 주입]
+      # 실제 값은 AWS Elastic Beanstalk 콘솔에서 설정한 값이 들어옵니다.
+      RDS_HOSTNAME: ${RDS_HOSTNAME}
+      RDS_PORT: ${RDS_PORT}
+      RDS_DB_NAME: ${RDS_DB_NAME}
+#      RDS_USERNAME: ${RDS_USERNAME} # AWS 파라미터 스토어에 spring.datasource.username 등록되어 있어서 필요 없음.
+#      RDS_PASSWORD: ${RDS_PASSWORD} # AWS 파라미터 스토어에 spring.datasource.password 등록되어 있어서 필요 없음.
+
+      S3_BUCKET: ${S3_BUCKET}
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID} # EB 환경 변수에 저장해야 함.
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY} # 금고 열쇠를 금고 안에 넣을 수는 없으니까 EB 환경변수에 평문 형태로 저장함.
+      AWS_REGION: ${AWS_REGION} # EB 환경 변수에 저장해야 함.
+
+#      JWT_SECRET_KEY: ${JWT_SECRET_KEY} # AWS 파라미터 스토어에 jwt.secret-key 등록되어 있어서 필요 없음.
+    depends_on:
+      - redis                   # redis가 먼저 켜져야 앱이 실행됨
+
+  # 2. Redis 서버 (Sidecar)
+  redis:
+    image: redis:alpine         # 가볍고 안정적인 알파인 리눅스 기반 Redis 이미지
+    command: redis-server --requirepass ${REDIS_PASSWORD} # 이 구문 때문에 REDIS_PASSWORD는 EB 환경변수에 따로 등록해야 함.
+    ports:
+      - "6379:6379"             # 내부 통신용 (외부 노출은 보안 그룹으로 막힘)

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,42 @@
+spring:
+  config:
+    activate:
+      on-profile: dev
+
+  datasource:
+    url: jdbc:h2:mem:testdb
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop # 껐다 켜면 데이터 초기화
+    show-sql: true
+    defer-datasource-initialization: true
+
+  sql:
+    init:
+      mode: always
+      data-locations: classpath:data.sql
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      password: redis1234! # 로컬용 비밀번호
+
+jwt:
+  secret-key: "your-very-long-jwt-secret-key-local-dev-only" # 로컬용 키
+  access-token-expire-ms: 900000 # 15분
+  refresh-token-expire-ms: 604800000 # 7일
+
+logging:
+  level:
+    org.springframework: DEBUG
+    com.safely: DEBUG

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,45 @@
+spring:
+  config:
+    activate:
+      on-profile: prod
+    # [핵심] AWS 파라미터 스토어의 값들을 내 설정처럼 불러옴
+    import: "aws-parameterstore:/config/safely/"
+
+  application:
+    name: safely
+
+  datasource:
+    # URL은 환경변수 조각들을 모아서 완성 (파라미터 스토어 X)
+    url: jdbc:mysql://${RDS_HOSTNAME}:${RDS_PORT}/${RDS_DB_NAME}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    # username 삭제됨 (파라미터 스토어에서 자동 주입)
+    # password 삭제됨 (파라미터 스토어에서 자동 주입)
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: false
+
+  data:
+    redis:
+      # Host, Port는 docker-compose나 EB 변수에서 받음 (보안 중요도 낮음)
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+      # password 삭제됨 (파라미터 스토어에서 자동 주입)
+
+  cloud:
+    aws:
+      s3:
+        bucket: ${S3_BUCKET}
+      region:
+        static: ap-northeast-2
+      credentials:
+        access-key: ${AWS_ACCESS_KEY_ID}
+        secret-key: ${AWS_SECRET_ACCESS_KEY}
+
+# jwt: 삭제됨 (파라미터 스토어에서 자동 주입)
+
+logging:
+  level:
+    org.springframework: INFO # 운영에서는 INFO 이상으로 하는 게 좋음
+    com.safely: INFO

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,61 +2,18 @@ spring:
   application:
     name: safely
 
-  datasource:
-    url: jdbc:h2:mem:testdb
-    driver-class-name: org.h2.Driver
-    username: sa
-    password:
-  h2:
-    console:
-      enabled: true
-      path: /h2-console
+  # 파일 업로드 용량 등 환경 무관 설정
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
 
+  # JPA 기본 설정 (DB 종류와 무관한 부분)
   jpa:
-    hibernate:
-      ddl-auto: create
-    defer-datasource-initialization: true  # Hibernate가 테이블을 다 만든 후에 data.sql을 실행하라는 뜻
+    open-in-view: false # 성능 최적화를 위해 false 권장
     properties:
       hibernate:
         format_sql: true
-    show-sql: true
 
-  sql:
-    init:
-      mode: always      # data.sql 실행
-#      schema-locations: classpath:old_schema.sql
-      data-locations: classpath:data.sql
-
-  data:
-    redis:
-      host: localhost
-      port: 6379
-      password: redis1234! # 개발 단계라서 하드코딩함. aws 배포 전 삭제 예정.
-
-  cloud:
-    aws:
-      s3:
-        bucket: ${S3_BUCKET}
-      region:
-        static: ap-northeast-2
-      credentials:
-        access-key: ${S3_ACCESS_KEY}
-        secret-key: ${S3_SECRET_KEY}
-
-    servlet:
-      multipart:
-        max-file-size: 10MB
-        max-request-size: 10MB
-
-#  main:
-#    allow-bean-definition-overriding: true  # 의존성 충돌이 나면 빈 덮어 씌우기 (swagger 최신버전으로 했다가 오류떠서 시도해 봄.)
-
-jwt:
-  secret-key: "your-very-long-jwt-secret-key-should-be-very-long" # 개발 단계 기본 비밀번호 이므로 GitHub에 그냥 올림.
-  access-token-expire-ms: 900000      # 15분
-  refresh-token-expire-ms: 604800000  # 7일
-
-logging:
-  level:
-    org.springframework.security: DEBUG
-    org.springframework.web: DEBUG
+# 기본적으로 dev 프로필을 활성화 (로컬에서 실행 시 자동 적용)
+spring.profiles.active: dev


### PR DESCRIPTION
## 📌 이슈 번호

- resolves #17 

## 🔎 변경 내용

**1. CI/CD 파이프라인 구축**
- GitHub Actions를 통해 `main` 브랜치 푸시 시 자동 빌드 및 배포되도록 설정
- AWS Elastic Beanstalk(Docker 플랫폼)을 배포 타겟으로 설정

**2. 인프라 구성 변경 (AWS Free Tier 최적화)**
- **DB:** AWS RDS (MySQL) 프리티어를 사용하도록 설정
- **Redis:** 별도 ElastiCache 비용 절감을 위해 `docker-compose`를 사용하여 EB 인스턴스 내부에서 Sidecar 형태로 실행되도록 구성

**3. 설정 파일 분리**
- `application.yml`: 공통 설정
- `application-dev.yml`: 로컬 개발용 (H2, Local Redis)
- `application-prod.yml`: 배포용 (RDS, Docker Redis, 환경 변수 주입)

## 📬 참고 사항

- 파라미터 스토어, EB 환경 변수, 깃허브 액션의 secrets에 환경 변수를 등록했습니다.
