### PR TITLE
fix: AWS 배포 후 브라우저로 서버 접속 안 되는 증상 debug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ ENV SPRING_PROFILES_ACTIVE=prod
 ENTRYPOINT ["java", "-jar", "app.jar"]
 
 # 6. 포트 노출 (AWS EB가 이 포트로 트래픽을 보냄)
-EXPOSE 8080
+EXPOSE 5000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   app:
     build: .                    # 현재 폴더의 Dockerfile을 사용하여 빌드
     ports:
-      - "80:8080"               # 외부 80 포트로 들어오면 -> 내부 8080(Spring)으로 연결
+      - "80:5000"               # 외부 80 포트로 들어오면 -> 내부 5000(Spring)으로 연결
     environment:
       # [프로필 설정]
       SPRING_PROFILES_ACTIVE: prod


### PR DESCRIPTION
## 📌 이슈 번호

- resolves #19 

## 🔎 변경 내용

- EC2 서버 PORT 80:8080에서 80:5000으로 변경

## 📬 참고 사항

- 브라우저로 서버 접속 안 되는 현상 버그 추적하고 있습니다.
