### PR TITLE
fix: groups 테이블명을 travel_groups로 변경

### DIFF
--- a/src/main/java/com/safely/domain/group/entity/Group.java
+++ b/src/main/java/com/safely/domain/group/entity/Group.java
@@ -15,7 +15,7 @@ import java.util.UUID;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "groups")
+@Table(name = "travel_groups")
 public class Group extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/safely/domain/group/entity/GroupMember.java
+++ b/src/main/java/com/safely/domain/group/entity/GroupMember.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "group_members")
+@Table(name = "travel_group_members")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 // BaseEntity의 created_at 컬럼을 joined_at으로 이름 변경하여 매핑
 @AttributeOverride(name = "created_at", column = @Column(name = "joined_at", nullable = false, updatable = false))


### PR DESCRIPTION
## 📌 이슈 번호

- resolves #26

## 🔎 변경 내용

- fix: groups 테이블명을 travel_groups로 변경

## 📬 참고 사항

- group가 mysql 예약어라서 groups로 한 건데, 이것도 예약어라고 함.
