### PR TITLE
ci/cd: 깃허브 액션에서 AWS OIDC 임시토큰 발급받는 방식으로 변경

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,6 +39,12 @@ jobs:
           # 보통 Docker 배포는 소스코드 + Dockerfile만 넘기면 EB가 알아서 빌드하거나,
           # 위처럼 JAR를 미리 만들었다면 Dockerfile COPY 경로에 주의해야 함.)
 
+      - name: Check jar exists # jar 파일 제대로 생성되었는지 테스트 하는 구문임
+        run: ls -al build/libs
+
+      - name: Check deploy.zip content # deploy.zip 파일 제대로 생성되었는지 테스트 하는 구문임
+        run: unzip -l deploy.zip | head -n 50
+
         # [중요 수정] AWS EB Docker 플랫폼은 기본적으로
         # 1. Dockerfile이 있으면 -> Docker build 수행
         # 2. docker-compose.yml이 있으면 -> Compose 수행
@@ -52,11 +58,30 @@ jobs:
           role-to-assume: arn:aws:iam::136022486037:role/github-actions-oidc-eb-deploy
           aws-region: ap-northeast-2
 
-      - name: Deploy to Elastic Beanstalk
-        uses: einaregilsson/beanstalk-deploy@v21
-        with:
-          application_name: safely-app          # AWS EB 앱 이름
-          environment_name: Safely-app-env       # AWS EB 환경 이름
-          version_label: "ver-${{ github.sha }}"
-          region: ap-northeast-2
-          deployment_package: deploy.zip
+      - name: Install AWS CLI
+        run: |
+          python -m pip install --upgrade pip
+          pip install awscli
+
+      - name: Deploy to Elastic Beanstalk (AWS CLI)
+        env:
+          APP_NAME: safely-app
+          ENV_NAME: Safely-app-env
+          REGION: ap-northeast-2
+          VERSION_LABEL: ver-${{ github.sha }}
+          EB_BUCKET: elasticbeanstalk-ap-northeast-2-136022486037
+        run: |
+          aws s3 ls "s3://$EB_BUCKET" --region $REGION
+          
+          aws s3 cp deploy.zip s3://$EB_BUCKET/$APP_NAME/$VERSION_LABEL.zip --region $REGION
+          
+          aws elasticbeanstalk create-application-version \
+            --application-name "$APP_NAME" \
+            --version-label "$VERSION_LABEL" \
+            --source-bundle S3Bucket=$EB_BUCKET,S3Key=$APP_NAME/$VERSION_LABEL.zip \
+            --region $REGION
+          
+          aws elasticbeanstalk update-environment \
+            --environment-name "$ENV_NAME" \
+            --version-label "$VERSION_LABEL" \
+            --region $REGION

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,13 @@ WORKDIR /app
 
 # 3. 빌드된 JAR 파일을 Docker 이미지 안으로 복사
 # Gradle 빌드 시 build/libs/ 안에 jar가 생김
-COPY build/libs/*.jar app.jar
+# `COPY build/libs/*.jar app.jar` 했을 때 실수로 jar파일 한 개 더 생기면 배포 실패 뜨므로
+# build.gradle에
+#    tasks.named("bootJar") {
+#       archiveFileName = "app.jar"
+#    }
+# 구문 추가하고, `COPY build/libs/app.jar app.jar`로 *.jar를 app.jar로 명시함
+COPY build/libs/app.jar app.jar
 
 # 4. 운영 환경 프로필(prod) 적용
 ENV SPRING_PROFILES_ACTIVE=prod

--- a/build.gradle
+++ b/build.gradle
@@ -56,3 +56,7 @@ dependencies {
 tasks.named('test') {
 	useJUnitPlatform()
 }
+
+tasks.named("bootJar") {
+    archiveFileName = "app.jar"
+}


### PR DESCRIPTION
## 📌 이슈 번호

- resolves #49

## 🔎 변경 내용

- deploy.yml, Dockerfile, build.gradle 파일 수정

## 📬 참고 사항

- 깃허브 액션에서 secret key 방식 -> OIDC 임시토큰 발급 방식으로 전환 할 때 배포 오류가 없도록 deploy.yml 파일 수정했습니다.
- 만약에 jar파일 두 개 이상이면 배포 실패가 예상되므로 Dockerfile, build.gradle 수정했습니다.