### PR TITLE
chore: 웹 취약점 스캐너의 스캔으로 인한 리소스 낭비 방지 코드 추가

### DIFF
--- a/.platform/nginx/conf.d/elasticbeanstalk/safely-server.conf
+++ b/.platform/nginx/conf.d/elasticbeanstalk/safely-server.conf
@@ -1,0 +1,51 @@
+if ($bad_bot) {
+    return 403;
+}
+
+location ~ /\.(?!well-known).* {
+    deny all;
+    access_log off;
+    log_not_found off;
+}
+
+location ~* ^/(phpmyadmin|wp-admin|wp-login\.php|xmlrpc\.php|cgi-bin|boaform|vendor) {
+    return 403;
+}
+
+location ^~ /swagger-ui/ {
+    limit_req zone=perip burst=20 nodelay;
+    limit_conn addr 10;
+}
+
+location = /swagger-ui.html {
+    limit_req zone=perip burst=20 nodelay;
+    limit_conn addr 10;
+}
+
+location ^~ /v3/api-docs/ {
+    limit_req zone=perip burst=20 nodelay;
+    limit_conn addr 10;
+}
+
+location = /v3/api-docs {
+    limit_req zone=perip burst=20 nodelay;
+    limit_conn addr 10;
+}
+
+location = /health {
+    access_log off;
+}
+
+location ^~ /actuator/ {
+    return 403;
+}
+
+location ^~ /api/auth/ {
+    limit_req zone=perip burst=5 nodelay;
+    limit_conn addr 10;
+}
+
+location / {
+    limit_req zone=perip burst=15 nodelay;
+    limit_conn addr 20;
+}

--- a/.platform/nginx/conf.d/elasticbeanstalk/security.conf
+++ b/.platform/nginx/conf.d/elasticbeanstalk/security.conf
@@ -1,9 +1,0 @@
-# 1. 쓸데없는 취약점 스캐너 봇 차단 (정규표현식)
-location ~* (\.php|\.cgi|\.aspx|\.jsp|\.env|\.git|\.txt|\.xml|/wp-|/vendor|/phpunit|/actuator) {
-    return 444;
-}
-
-# 2. 이상한 HTTP 메서드 차단
-if ($request_method !~ ^(GET|POST|PUT|DELETE|OPTIONS|HEAD)$) {
-    return 444;
-}

--- a/.platform/nginx/conf.d/rate-limit.conf
+++ b/.platform/nginx/conf.d/rate-limit.conf
@@ -1,0 +1,14 @@
+limit_req_zone $binary_remote_addr zone=perip:10m rate=10r/s;
+limit_conn_zone $binary_remote_addr zone=addr:10m;
+
+map $http_user_agent $bad_bot {
+    default 0;
+    ~*sqlmap 1;
+    ~*nikto 1;
+    ~*acunetix 1;
+    ~*nmap 1;
+    ~*masscan 1;
+    ~*zgrab 1;
+    ~*python-requests 1;
+    ~*wget 1;
+}


### PR DESCRIPTION
## 📌 이슈 번호

- resolves #74 

## 🔎 변경 내용

- nginx 설정 파일의 경로가 잘못되어 다시 바꿨습니다.

## 📬 참고 사항

- 웹 취약점 스캐너 스캔 시 return 444 하도록 nginx 설정 파일의 경로를 바꿨습니다.
