### PR TITLE
refactor: S3 퍼블릭 차단 기능 활성화 및 redis 사이드카 방식을 ElastiCache 방식으로 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,11 @@ out/
 ### VS Code ###
 .vscode/
 
+# AWS
+.aws/
+*.pem
+.env
+.env.local
+
 ### Custom ###
 safely.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,28 +7,5 @@ services:
       - "80:5000"
     environment:
       SPRING_PROFILES_ACTIVE: prod
-
-      REDIS_HOST: redis
-      REDIS_PORT: 6379
-#      REDIS_PASSWORD: ${REDIS_PASSWORD} # AWS 파라미터 스토어에 spring.data.redis.password 등록되어 있어서 주석 처리함.
-
-#      RDS DB URL은 AWS 파라미터 스토어에 spring.datasource.url 등록되어 있음.
-#      RDS_USERNAME: ${RDS_USERNAME} # AWS 파라미터 스토어에 spring.datasource.username 등록되어 있어서 주석 처리함.
-#      RDS_PASSWORD: ${RDS_PASSWORD} # AWS 파라미터 스토어에 spring.datasource.password 등록되어 있어서 주석 처리함.
-
-#      S3_BUCKET: ${S3_BUCKET} # AWS 파라미터 스토어에 등록되어 있어서 주석 처리함.
-#      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID} # AWS OIDC 방식으로 임시 토큰 발급받아 접속하므로 주석 처리함.
-#      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY} # AWS OIDC 방식으로 임시 토큰 발급받아 접속하므로 주석 처리함.
-      AWS_REGION: ${AWS_REGION:-ap-northeast-2} # ${VAR:-default} 문법으로 기본값을 지정
-
-#      JWT_SECRET_KEY: ${JWT_SECRET_KEY} # AWS 파라미터 스토어에 jwt.secret-key 등록되어 있어서 주석 처리함.
-    depends_on:
-      - redis                   # redis가 먼저 켜져야 앱이 실행됨.
-
-  redis:
-    image: redis:alpine
-    command: redis-server
-         # 사이드카로 컨테이너 두 개 띄운 뒤에 같은 도커 네트워크 안에서 로컬로 접속하니까 보안은 비번 없이 네트워크 격리로 충분할 때가 많음.
-         # 6379포트만 외부 접속 막아야 함. (AWS 보안그룹에서 6379 포트 인바운드 막아야 함.)
-    ports:
-      - "6379:6379"             # 내부 통신용 (외부 노출은 보안 그룹으로 막힘)
+      AWS_REGION: ${AWS_REGION:-ap-northeast-2}
+      # Redis 환경변수 모두 제거 (ElastiCache는 SSM 경유)

--- a/src/main/java/com/safely/global/config/RedisConfig.java
+++ b/src/main/java/com/safely/global/config/RedisConfig.java
@@ -1,42 +1,28 @@
 package com.safely.global.config;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
-import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 public class RedisConfig {
-    @Value("${spring.data.redis.host}")
-    private String host;
 
-    @Value("${spring.data.redis.port}")
-    private int port;
-
-    @Bean
-    public RedisConnectionFactory redisConnectionFactory() {
-        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
-        config.setHostName(host);
-        config.setPort(port);
-
-        return new LettuceConnectionFactory(config);
-    }
+    /**
+     * ConnectionFactory 빈은 정의하지 않습니다.
+     * Spring Boot 자동 설정이 spring.data.redis.* 프로퍼티를 읽어
+     * SSL, AUTH 토큰까지 포함하여 LettuceConnectionFactory를 만듭니다.
+     */
 
     @Bean
     public RedisTemplate<String, String> redisTemplate(
             RedisConnectionFactory connectionFactory
     ) {
-        RedisTemplate<String, String> template =
-                new RedisTemplate<>();
-
+        RedisTemplate<String, String> template = new RedisTemplate<>();
         template.setConnectionFactory(connectionFactory);
         template.setKeySerializer(new StringRedisSerializer());
         template.setValueSerializer(new StringRedisSerializer());
-
         return template;
     }
 }

--- a/src/main/java/com/safely/global/s3/S3Service.java
+++ b/src/main/java/com/safely/global/s3/S3Service.java
@@ -22,7 +22,7 @@ import java.util.UUID;
 public class S3Service {
     private final S3Template s3Template;
 
-    @Value("${spring.cloud.aws.s3.bucket}")
+    @Value("${aws.s3.bucket}")
     private String bucketName;
 
     private static final Set<String> ALLOWED_EXTENSIONS = Set.of(".jpg", ".jpeg", ".png", ".gif", ".webp");

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -37,16 +37,15 @@ spring:
       port: 6379
 
   # 로컬 개발 환경에서만 Access Key 사용. prod 환경은 OIDC 임시 토큰 발급받는 방식으로 사용
-  cloud:
-    aws:
-      credentials:
-        access-key: ${AWS_ACCESS_KEY_ID}
-        secret-key: ${AWS_SECRET_ACCESS_KEY}
 
 jwt:
   secret-key: "your-very-long-jwt-secret-key-local-dev-only"
   access-token-expire-ms: 900000
   refresh-token-expire-ms: 604800000
+
+aws:
+  s3:
+    bucket: ${AWS_S3_BUCKET}
 
 logging:
   level:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -8,14 +8,9 @@ spring:
       on-profile: prod
     import: "aws-parameterstore:/config/safely/"
 
-  application:
-    name: safely
-
   datasource:
-    # url 삭제됨 (파라미터 스토어에서 자동 주입)
     driver-class-name: com.mysql.cj.jdbc.Driver
-    # username 삭제됨 (파라미터 스토어에서 자동 주입)
-    # password 삭제됨 (파라미터 스토어에서 자동 주입)
+    # url, username, password는 AWS SSM에서 자동 주입
 
   jpa:
     hibernate:
@@ -24,12 +19,15 @@ spring:
 
   data:
     redis:
-      # Host, Port는 docker-compose.yml에서 받음
-      host: ${REDIS_HOST}
-      port: ${REDIS_PORT}
-      # password 삭제됨(redis 서버는 도커 컨테이너로 사이드카 방식을 사용하므로 REDIS PORT로의 외부 접속만 차단하면 되어서 비번 삭제함)
-
-# jwt: 삭제됨 (파라미터 스토어에서 자동 주입)
+      # host, port, password는 SSM에서 자동 주입
+      ssl:
+        enabled: true   # ElastiCache TLS 활성화
+      timeout: 3000ms
+      lettuce:
+        pool:
+          max-active: 8
+          max-idle: 8
+          min-idle: 2
 
 logging:
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,16 +8,15 @@ spring:
       max-request-size: 10MB
 
   jpa:
-    open-in-view: false # 성능 최적화를 위해 false 권장
+    open-in-view: false
     properties:
       hibernate:
         format_sql: true
 
-  cloud:
-    aws:
-      s3:
-        bucket: ${S3_BUCKET}
-      region:
-        static: ap-northeast-2
+  profiles:
+    active: dev
 
-spring.profiles.active: dev
+cloud:
+  aws:
+    region:
+      static: ap-northeast-2


### PR DESCRIPTION
## 📌 이슈 번호

- resolves #86

## 🔎 변경 내용

- aws 프리티어 기간 종료로 프리티어 가능한 다른 aws 계정으로 마이그레이션
- S3 퍼블릭 차단 활성화
- redis 사이드카 방식을 ElastiCache 방식으로 변경

## 📬 참고 사항

- 기존의 redis 사이드카 방식은 EC2 재배포시 데이터가 날아가며, 메모리를 스프링 부트 JVM과 경쟁하는 단점이 있습니다.
- 스케일아웃하면 인스턴스마다 별도의 redis 서버가 떠서 캐시 일관성이 깨지게 됩니다. 따라서 ElastiCache로 바꿨습니다.
