### PR TITLE
fix: CI/CD 오류 (S3 bucket 이름 등이 예전 계정으로 된 오류) 및 테스트 오류 뜨는 거 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::136022486037:role/github-actions-oidc-eb-deploy
+          role-to-assume: arn:aws:iam::267673636133:role/safely-github-deploy-role
           aws-region: ap-northeast-2
 
       - name: Install AWS CLI
@@ -64,7 +64,7 @@ jobs:
           REGION: ap-northeast-2
           # 깃허브 액션에서 rerun 눌렀을 때도 버전레이블 중복 없이 배포 성공할 수 있도록 github.run_number, github.run_attempt 추가
           VERSION_LABEL: ver-${{ github.sha }}-${{ github.run_number }}-${{ github.run_attempt }}
-          EB_BUCKET: elasticbeanstalk-ap-northeast-2-136022486037
+          EB_BUCKET: elasticbeanstalk-ap-northeast-2-267673636133
         run: |          
           aws s3 cp deploy.zip s3://$EB_BUCKET/$APP_NAME/$VERSION_LABEL.zip --region $REGION
           

--- a/src/test/java/com/safely/SafelyApplicationTests.java
+++ b/src/test/java/com/safely/SafelyApplicationTests.java
@@ -1,7 +1,9 @@
 package com.safely;
 
+import com.safely.global.s3.S3Service;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest
 class SafelyApplicationTests {

--- a/src/test/java/com/safely/domain/auth/service/AuthServiceIntegrationTest.java
+++ b/src/test/java/com/safely/domain/auth/service/AuthServiceIntegrationTest.java
@@ -8,7 +8,6 @@ import com.safely.domain.auth.entity.CustomUserDetails;
 import com.safely.domain.member.entity.Member;
 import com.safely.domain.member.repository.MemberRepository;
 import com.safely.global.exception.auth.EmailDuplicateException;
-import com.safely.global.exception.auth.InvalidTokenException;
 import com.safely.global.exception.auth.RefreshTokenNotFoundException;
 import com.safely.global.exception.common.EntityNotFoundException;
 import com.safely.global.security.jwt.JwtProvider;
@@ -18,7 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -45,10 +44,9 @@ class AuthServiceIntegrationTest {
     @Autowired AuthService authService;
     @Autowired MemberRepository memberRepository;
     @Autowired PasswordEncoder passwordEncoder;
-    @Autowired
-    JwtProvider jwtProvider;
+    @Autowired JwtProvider jwtProvider;
 
-    @MockitoBean RedisConnectionFactory redisConnectionFactory;
+    @MockitoBean LettuceConnectionFactory redisConnectionFactory;
     @MockitoBean RedisTemplate<String, String> redisTemplate;
     @MockitoBean ValueOperations<String, String> valueOperations;
     @MockitoBean AuthenticationManager authenticationManager;

--- a/src/test/java/com/safely/domain/group/service/GroupServiceIntegrationTest.java
+++ b/src/test/java/com/safely/domain/group/service/GroupServiceIntegrationTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.redis.connection.RedisConnectionFactory; // 추가
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,7 +36,7 @@ class GroupServiceIntegrationTest {
     @Autowired EntityManager em;
 
     // GroupService 테스트지만 ApplicationContext가 뜰 때 Redis를 찾을 수 있으므로 안전장치 추가
-    @MockitoBean RedisConnectionFactory redisConnectionFactory;
+    @MockitoBean LettuceConnectionFactory redisConnectionFactory;
 
     @Test
     @DisplayName("통합: 그룹 생성 시 멤버가 MANAGER로 등록되고 날짜가 저장된다.")

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -19,7 +19,6 @@ spring:
     init:
       mode: always
 
-  # Redis 설정 (테스트에서는 리포지토리 비활성화)
   data:
     redis:
       repositories:
@@ -32,23 +31,21 @@ spring:
       max-file-size: 10MB
       max-request-size: 10MB
 
-  # 가짜 AWS 설정 (S3_BUCKET 오류 및 빈 생성 실패 해결)
   cloud:
     aws:
-      s3:
-        bucket: test-bucket-dummy
       region:
         static: ap-northeast-2
-      credentials:
-        access-key: test-access-key
-        secret-key: test-secret-key
       stack:
         auto: false
 
+aws:
+  s3:
+    bucket: test-bucket-dummy
+
 jwt:
   secret-key: "test-very-long-secret-key-for-unit-tests-must-be-secure"
-  access-token-expire-ms: 6000 # 10분
-  refresh-token-expire-ms: 1200000 # 20분
+  access-token-expire-ms: 60000
+  refresh-token-expire-ms: 1200000
 
 logging:
   level:


### PR DESCRIPTION
## 📌 이슈 번호

- resolves #89

## 🔎 변경 내용

- CI/CD 오류 (S3 bucket 이름 등이 예전 계정으로 된 오류 수정
- SafelyApplicationTests 오류 수정
- AuthServiceIntegrationTest, GroupServiceIntegrationTest 오류 수정


## 📬 참고 사항

- deploy.yml 파일의 S3 Bucket 명과 aws 역할 등을 예전 이름에서 현재 이름으로 바꿨습니다.
- test/application.yml 파일에서 spring.cloud prefix를 제거하고, aws.s3.bucket으로 더미값을 넣어서 @Value값과 매핑했습니다.
- RedisConnectionFactory를 구현체인 LettuceConnectionFactory로 교체하여 다른 인터페이스로 형변환이 가능하도록 했습니다.
