### PR TITLE
refactor: redis 서버를 AWS ElastiCache에서 도커 사이드카 방식으로 원복

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,5 +7,28 @@ services:
       - "80:5000"
     environment:
       SPRING_PROFILES_ACTIVE: prod
-      AWS_REGION: ${AWS_REGION:-ap-northeast-2}
-      # Redis 환경변수 모두 제거 (ElastiCache는 SSM 경유)
+
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+#      REDIS_PASSWORD: ${REDIS_PASSWORD} # AWS 파라미터 스토어에 spring.data.redis.password 등록되어 있어서 주석 처리함.
+
+#      RDS DB URL은 AWS 파라미터 스토어에 spring.datasource.url 등록되어 있음.
+#      RDS_USERNAME: ${RDS_USERNAME} # AWS 파라미터 스토어에 spring.datasource.username 등록되어 있어서 주석 처리함.
+#      RDS_PASSWORD: ${RDS_PASSWORD} # AWS 파라미터 스토어에 spring.datasource.password 등록되어 있어서 주석 처리함.
+
+#      S3_BUCKET: ${S3_BUCKET} # AWS 파라미터 스토어에 등록되어 있어서 주석 처리함.
+#      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID} # AWS OIDC 방식으로 임시 토큰 발급받아 접속하므로 주석 처리함.
+#      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY} # AWS OIDC 방식으로 임시 토큰 발급받아 접속하므로 주석 처리함.
+      AWS_REGION: ${AWS_REGION:-ap-northeast-2} # ${VAR:-default} 문법으로 기본값을 지정
+
+#      JWT_SECRET_KEY: ${JWT_SECRET_KEY} # AWS 파라미터 스토어에 jwt.secret-key 등록되어 있어서 주석 처리함.
+    depends_on:
+      - redis                   # redis가 먼저 켜져야 앱이 실행됨.
+
+  redis:
+    image: redis:alpine
+    command: redis-server
+         # 사이드카로 컨테이너 두 개 띄운 뒤에 같은 도커 네트워크 안에서 로컬로 접속하니까 보안은 비번 없이 네트워크 격리로 충분할 때가 많음.
+         # 6379포트만 외부 접속 막아야 함. (AWS 보안그룹에서 6379 포트 인바운드 막아야 함.)
+    ports:
+      - "6379:6379"             # 내부 통신용 (외부 노출은 보안 그룹으로 막힘)

--- a/src/main/java/com/safely/global/config/RedisConfig.java
+++ b/src/main/java/com/safely/global/config/RedisConfig.java
@@ -1,28 +1,42 @@
 package com.safely.global.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 public class RedisConfig {
+    @Value("${spring.data.redis.host}")
+    private String host;
 
-    /**
-     * ConnectionFactory 빈은 정의하지 않습니다.
-     * Spring Boot 자동 설정이 spring.data.redis.* 프로퍼티를 읽어
-     * SSL, AUTH 토큰까지 포함하여 LettuceConnectionFactory를 만듭니다.
-     */
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
+        config.setHostName(host);
+        config.setPort(port);
+
+        return new LettuceConnectionFactory(config);
+    }
 
     @Bean
     public RedisTemplate<String, String> redisTemplate(
             RedisConnectionFactory connectionFactory
     ) {
-        RedisTemplate<String, String> template = new RedisTemplate<>();
+        RedisTemplate<String, String> template =
+                new RedisTemplate<>();
+
         template.setConnectionFactory(connectionFactory);
         template.setKeySerializer(new StringRedisSerializer());
         template.setValueSerializer(new StringRedisSerializer());
+
         return template;
     }
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -19,15 +19,12 @@ spring:
 
   data:
     redis:
-      # host, port, password는 SSM에서 자동 주입
-      ssl:
-        enabled: true   # ElastiCache TLS 활성화
-      timeout: 3000ms
-      lettuce:
-        pool:
-          max-active: 8
-          max-idle: 8
-          min-idle: 2
+      # Host, Port는 docker-compose.yml에서 받음
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+      # password 삭제됨(redis 서버는 도커 컨테이너로 사이드카 방식을 사용하므로 REDIS PORT로의 외부 접속만 차단하면 되어서 비번 삭제함)
+
+# jwt: 삭제됨 (파라미터 스토어에서 자동 주입)
 
 logging:
   level:

--- a/src/test/java/com/safely/domain/group/service/GroupServiceIntegrationTest.java
+++ b/src/test/java/com/safely/domain/group/service/GroupServiceIntegrationTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.connection.RedisConnectionFactory; // 추가
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,7 +36,7 @@ class GroupServiceIntegrationTest {
     @Autowired EntityManager em;
 
     // GroupService 테스트지만 ApplicationContext가 뜰 때 Redis를 찾을 수 있으므로 안전장치 추가
-    @MockitoBean LettuceConnectionFactory redisConnectionFactory;
+    @MockitoBean RedisConnectionFactory redisConnectionFactory;
 
     @Test
     @DisplayName("통합: 그룹 생성 시 멤버가 MANAGER로 등록되고 날짜가 저장된다.")


### PR DESCRIPTION
## 📌 이슈 번호

- resolves #92 

## 🔎 변경 내용

- redis 서버를 AWS ElastiCache에서 도커 사이드카 방식으로 원복

## 📬 참고 사항

- AWS 운영 비용 문제 때문에 일단 도커 사이드카 방식으로 원복합니다.
