### PR TITLE
ci/cd: docker 컨테이너 로그 용량 제한 추가 및 redis 포트 노출 제거

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,25 +10,43 @@ services:
 
       REDIS_HOST: redis
       REDIS_PORT: 6379
-#      REDIS_PASSWORD: ${REDIS_PASSWORD} # AWS 파라미터 스토어에 spring.data.redis.password 등록되어 있어서 주석 처리함.
+      #      REDIS_PASSWORD: ${REDIS_PASSWORD} # AWS 파라미터 스토어에 spring.data.redis.password 등록되어 있어서 주석 처리함.
 
-#      RDS DB URL은 AWS 파라미터 스토어에 spring.datasource.url 등록되어 있음.
-#      RDS_USERNAME: ${RDS_USERNAME} # AWS 파라미터 스토어에 spring.datasource.username 등록되어 있어서 주석 처리함.
-#      RDS_PASSWORD: ${RDS_PASSWORD} # AWS 파라미터 스토어에 spring.datasource.password 등록되어 있어서 주석 처리함.
+      #      RDS DB URL은 AWS 파라미터 스토어에 spring.datasource.url 등록되어 있음.
+      #      RDS_USERNAME: ${RDS_USERNAME} # AWS 파라미터 스토어에 spring.datasource.username 등록되어 있어서 주석 처리함.
+      #      RDS_PASSWORD: ${RDS_PASSWORD} # AWS 파라미터 스토어에 spring.datasource.password 등록되어 있어서 주석 처리함.
 
-#      S3_BUCKET: ${S3_BUCKET} # AWS 파라미터 스토어에 등록되어 있어서 주석 처리함.
-#      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID} # AWS OIDC 방식으로 임시 토큰 발급받아 접속하므로 주석 처리함.
-#      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY} # AWS OIDC 방식으로 임시 토큰 발급받아 접속하므로 주석 처리함.
+      #      S3_BUCKET: ${S3_BUCKET} # AWS 파라미터 스토어에 등록되어 있어서 주석 처리함.
+      #      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID} # AWS OIDC 방식으로 임시 토큰 발급받아 접속하므로 주석 처리함.
+      #      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY} # AWS OIDC 방식으로 임시 토큰 발급받아 접속하므로 주석 처리함.
       AWS_REGION: ${AWS_REGION:-ap-northeast-2} # ${VAR:-default} 문법으로 기본값을 지정
 
-#      JWT_SECRET_KEY: ${JWT_SECRET_KEY} # AWS 파라미터 스토어에 jwt.secret-key 등록되어 있어서 주석 처리함.
+    #      JWT_SECRET_KEY: ${JWT_SECRET_KEY} # AWS 파라미터 스토어에 jwt.secret-key 등록되어 있어서 주석 처리함.
+
+    #   AWS에서 EC2 인스턴스에 로그 파일이 쌓여서 /가 100% 되지 않도록 max-size와 max-file 제한함.
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+
     depends_on:
       - redis                   # redis가 먼저 켜져야 앱이 실행됨.
 
   redis:
     image: redis:alpine
     command: redis-server
-         # 사이드카로 컨테이너 두 개 띄운 뒤에 같은 도커 네트워크 안에서 로컬로 접속하니까 보안은 비번 없이 네트워크 격리로 충분할 때가 많음.
-         # 6379포트만 외부 접속 막아야 함. (AWS 보안그룹에서 6379 포트 인바운드 막아야 함.)
-    ports:
-      - "6379:6379"             # 내부 통신용 (외부 노출은 보안 그룹으로 막힘)
+
+    #    ports:
+    #      - "6379:6379"        # 코드 제거함.
+    #    앱과 redis는 같은 도커 네트워크 안에서 서비스명(redis)으로 통신하니까 포트 매핑 자체가 불필요.
+    #    이 코드 제거하면 호스트에 아예 노출되지 않아서 보안 그룹에 의존할 필요가 없어짐.
+    #    참고로 남겨두는 예전 주석 - # 사이드카로 컨테이너 두 개 띄운 뒤에 같은 도커 네트워크 안에서 로컬로 접속하니까
+    #                            # 보안은 비번 없이 네트워크 격리로 충분할 때가 많음.
+    #                            # 6379포트만 외부 접속 막아야 함. (AWS 보안그룹에서 6379 포트 인바운드 막아야 함.)
+
+    logging: # AWS에서 EC2 인스턴스에 로그 파일이 쌓여서 /가 100% 되지 않도록 max-size와 max-file 제한함.
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"


### PR DESCRIPTION
## 📌 이슈 번호

- resolves #95

## 🔎 변경 내용

- docker 컨테이너 로그 용량 제한 추가 및 redis 포트 노출 제거

## 📬 참고 사항

- docker-compose.yml 파일 app, redis에 로그 파일 용량 제한
- redis 포트 매핑 제거 (도커 네트워크 내부 통신만 사용)
